### PR TITLE
Less Static keywords & return type changes

### DIFF
--- a/Image.c
+++ b/Image.c
@@ -1,14 +1,14 @@
 #include <pebble.h>
 #include "Image.h"
 
-struct Image * init_image(GRect spatialInfo, uint32_t resource_id, Layer *window_layer) {
+struct Image * init_image(GRect spatial_info, uint32_t resource_id, Layer *window_layer) {
     struct Image * image_struct = (struct Image *) malloc(sizeof(struct Image));
     
-    image_struct->image_dimension_position = spatialInfo;
+    image_struct->image_dimension_position = spatial_info;
     image_struct->image_resource_id = resource_id;
 
-    image_struct->image = gbitmap_create_with_resource(image_struct->image_resource_id);
-    image_struct->image_layer = bitmap_layer_create(image_struct->image_dimension_position);
+    image_struct->image = gbitmap_create_with_resource(resource_id);
+    image_struct->image_layer = bitmap_layer_create(spatial_info);
     bitmap_layer_set_compositing_mode(image_struct->image_layer, GCompOpSet);
     bitmap_layer_set_bitmap(image_struct->image_layer, image_struct->image);
     layer_add_child(window_layer, bitmap_layer_get_layer(image_struct->image_layer));

--- a/Image.c
+++ b/Image.c
@@ -1,7 +1,7 @@
 #include <pebble.h>
 #include "Image.h"
 
-static struct Image * init_image(GRect spatialInfo, uint32_t resource_id, Layer *window_layer) {
+struct Image * init_image(GRect spatialInfo, uint32_t resource_id, Layer *window_layer) {
     struct Image * image_struct = (struct Image *) malloc(sizeof(struct Image));
     
     image_struct->image_dimension_position = spatialInfo;
@@ -16,7 +16,7 @@ static struct Image * init_image(GRect spatialInfo, uint32_t resource_id, Layer 
     return image_struct;
 }
 
-static void destroy_image_struct(struct Image * image_struct) {
+void destroy_image_struct(struct Image * image_struct) {
     gbitmap_destroy(image_struct->image);
     bitmap_layer_destroy(image_struct->image_layer);
 }

--- a/Image.h
+++ b/Image.h
@@ -8,5 +8,5 @@ struct Image
     GBitmap *image;
     BitmapLayer *image_layer;
 };
-struct Image * init_image(GRect spatialInfo, uint32_t resource_id, Layer *window_layer);
+struct Image * init_image(GRect spatial_info, uint32_t resource_id, Layer *window_layer);
 void destroy_image_struct(struct Image *image_struct);

--- a/Image.h
+++ b/Image.h
@@ -8,5 +8,5 @@ struct Image
     GBitmap *image;
     BitmapLayer *image_layer;
 };
-static struct Image * init_image(GRect spatialInfo, uint32_t resource_id, Layer *window_layer);
-static void destroy_image_struct(struct Image *image_struct);
+struct Image * init_image(GRect spatialInfo, uint32_t resource_id, Layer *window_layer);
+void destroy_image_struct(struct Image *image_struct);

--- a/Images.c
+++ b/Images.c
@@ -2,14 +2,14 @@
 #include "Images.h"
 #include "Image.h"
 
-static void init_images_struct(struct Images * image_list, uint32_t number_of_images) {
+void init_images_struct(struct Images * image_list, uint32_t number_of_images) {
     // Access the pointer for the array of pointers and have it point to the memory just allocated.
     image_list->image_array = (struct Image **) malloc(sizeof(struct Image) * number_of_images);
     image_list->length = number_of_images;
     image_list->top = 0;
 }
 
-static void add_image(struct Images *image_list, GRect bounds, uint32_t resource_id, Layer *window_layer)
+void add_image(struct Images *image_list, GRect bounds, uint32_t resource_id, Layer *window_layer)
 {
     struct Image *image_struct = init_image(bounds, resource_id, window_layer);
     push_image(image_list, image_struct);
@@ -29,7 +29,7 @@ static void push_image(struct Images * image_list, struct Image * input_image) {
 }
 
 // Free what the image struct pointers are pointing at and then free the array holding the pointers.
-static void de_init_images_struct(struct Images * image_list) {
+void de_init_images_struct(struct Images * image_list) {
     for (uint32_t i = 0; i < image_list->length; i++) {
         // Destroy the image, the image_struct, and then the pointer to the image struct.
         destroy_image_struct((image_list->image_array)[i]);

--- a/Images.c
+++ b/Images.c
@@ -17,7 +17,7 @@ void add_image(struct Images *image_list, GRect bounds, uint32_t resource_id, La
     push_image(image_list, image_struct);
 }
 
-static void push_image(struct Images * image_list, struct Image * input_image) {
+void push_image(struct Images * image_list, struct Image * input_image) {
     // Access the pointer for the array on pointers and then write the new image pointer value to the next unused slot.
     if (image_list->top != (image_list->length - 1))
     {

--- a/Images.c
+++ b/Images.c
@@ -2,13 +2,12 @@
 #include "Images.h"
 #include "Image.h"
 
-void init_images_struct(struct Images * image_list, uint32_t number_of_images) {
-    // Allocate memory for the Images struct.
-    image_list = (struct Images *)malloc(sizeof(struct Images));
-    // Access the pointer for the array of pointers and have it point to the memory just allocated.
-    image_list->image_array = (struct Image **) malloc(sizeof(struct Image *) * number_of_images);
+struct Images * init_images_struct(uint32_t number_of_images) {
+    struct Images *image_list = (struct Images *)malloc(sizeof(struct Images)); // allocate images struct
+    image_list->image_array = (struct Image **)malloc(sizeof(struct Image *));  // allocate images array
     image_list->length = number_of_images;
     image_list->top = 0;
+    return image_list;
 }
 
 void add_image(struct Images *image_list, GRect bounds, uint32_t resource_id, Layer *window_layer)
@@ -21,7 +20,7 @@ void push_image(struct Images * image_list, struct Image * input_image) {
     // Access the pointer for the array on pointers and then write the new image pointer value to the next unused slot.
     if (image_list->top != (image_list->length))
     {
-        (image_list->image_array)[image_list->top] = input_image;
+        image_list->image_array[image_list->top] = input_image;
         image_list->top = image_list->top + 1;
     }
     else
@@ -34,8 +33,9 @@ void push_image(struct Images * image_list, struct Image * input_image) {
 void de_init_images_struct(struct Images * image_list) {
     for (uint32_t i = 0; i < image_list->length; i++) {
         // Destroy the image, the image_struct, and then the pointer to the image struct.
-        destroy_image_struct((image_list->image_array)[i]);
+        destroy_image_struct(image_list->image_array[i]);
         free((image_list->image_array)[i]);
     }
     free(image_list->image_array);
+    free(image_list);
 }

--- a/Images.c
+++ b/Images.c
@@ -19,7 +19,7 @@ void add_image(struct Images *image_list, GRect bounds, uint32_t resource_id, La
 
 void push_image(struct Images * image_list, struct Image * input_image) {
     // Access the pointer for the array on pointers and then write the new image pointer value to the next unused slot.
-    if (image_list->top != (image_list->length - 1))
+    if (image_list->top != (image_list->length))
     {
         (image_list->image_array)[image_list->top] = input_image;
         image_list->top = image_list->top + 1;

--- a/Images.c
+++ b/Images.c
@@ -3,8 +3,10 @@
 #include "Image.h"
 
 void init_images_struct(struct Images * image_list, uint32_t number_of_images) {
+    // Allocate memory for the Images struct.
+    image_list = (struct Images *)malloc(sizeof(struct Images));
     // Access the pointer for the array of pointers and have it point to the memory just allocated.
-    image_list->image_array = (struct Image **) malloc(sizeof(struct Image) * number_of_images);
+    image_list->image_array = (struct Image **) malloc(sizeof(struct Image *) * number_of_images);
     image_list->length = number_of_images;
     image_list->top = 0;
 }

--- a/Images.h
+++ b/Images.h
@@ -9,7 +9,7 @@ struct Images
     struct Image **image_array; // array of pointers
 };
 
-static void init_images_struct(struct Images *image_list, uint32_t number_of_images);
-static void add_image(struct Images *image_list, GRect bounds, uint32_t resource_id, Layer *window_layer);
+void init_images_struct(struct Images *image_list, uint32_t number_of_images);
+void add_image(struct Images *image_list, GRect bounds, uint32_t resource_id, Layer *window_layer);
 static void push_image(struct Images *image_list, struct Image *input_image);
-static void de_init_images_struct(struct Images *image_list);
+void de_init_images_struct(struct Images *image_list);

--- a/Images.h
+++ b/Images.h
@@ -9,7 +9,7 @@ struct Images
     struct Image **image_array; // array of pointers
 };
 
-void init_images_struct(struct Images *image_list, uint32_t number_of_images);
+struct Images * init_images_struct(uint32_t number_of_images);
 void add_image(struct Images *image_list, GRect bounds, uint32_t resource_id, Layer *window_layer);
 void push_image(struct Images *image_list, struct Image *input_image);
 void de_init_images_struct(struct Images *image_list);

--- a/Images.h
+++ b/Images.h
@@ -11,5 +11,5 @@ struct Images
 
 void init_images_struct(struct Images *image_list, uint32_t number_of_images);
 void add_image(struct Images *image_list, GRect bounds, uint32_t resource_id, Layer *window_layer);
-static void push_image(struct Images *image_list, struct Image *input_image);
+void push_image(struct Images *image_list, struct Image *input_image);
 void de_init_images_struct(struct Images *image_list);


### PR DESCRIPTION
I removed some static keywords that were not needed.
I changed the return type of the init_images_struct() function such that you store the return value when calling it rather than passing an empty pointer to be filled.
Perhaps later it would be good to return to the previous configuration and have the function return an error value if applicable.