### PR TITLE
Return text pointer

### DIFF
--- a/Texts.c
+++ b/Texts.c
@@ -26,15 +26,16 @@ struct Texts * init_texts_struct(uint32_t number_of_texts, GColor text_color, GC
     return texts_struct;
 }
 
-void add_text(struct Texts * text_list, GRect spatial_info, char * text, Layer * window_layer) {
+struct Text * add_text(struct Texts * text_list, GRect spatial_info, char * text, Layer * window_layer) {
     struct Text * new_text = init_text_struct(spatial_info, text, text_list->text_color, text_list->bg_color, text_list->font, window_layer);
     if (new_text == NULL)
     {
         APP_LOG(APP_LOG_LEVEL_ERROR, "init_text_struct returned NULL. Cannot push to array.");
-        return;
+        return NULL;
     }
     push_text(text_list, new_text);
     APP_LOG(APP_LOG_LEVEL_INFO, "new text pushed!");
+    return new_text;
 }
 
 void push_text(struct Texts * text_list, struct Text * input_text) {

--- a/Texts.h
+++ b/Texts.h
@@ -12,6 +12,6 @@ struct Texts {
 };
 
 struct Texts * init_texts_struct(uint32_t number_of_texts, GColor text_color, GColor bg_color, uint32_t font_resource_id, Layer * window_layer);
-void add_text(struct Texts * text_list, GRect spatial_info, char * text, Layer * window_layer);
+struct Text * add_text(struct Texts * text_list, GRect spatial_info, char * text, Layer * window_layer);
 void push_text(struct Texts * text_list, struct Text * input_text);
 void destroy_texts_struct(struct Texts * texts_struct);

--- a/appmessage.c
+++ b/appmessage.c
@@ -1,0 +1,31 @@
+#include <pebble.h>
+const int inbox_size = 128;
+const int outbox_size = 128;
+
+void inbox_received() {
+
+}
+
+void inbox_dropped() {
+    
+}
+
+void outbox_failed() {
+
+}
+
+void outbox_sent() {
+
+}
+
+void register_app_message_boxes() {
+    app_message_register_inbox_received(inbox_received);
+    app_message_register_inbox_dropped(inbox_dropped);
+    app_message_register_outbox_failed(outbox_failed);
+    app_message_register_outbox_sent(outbox_sent);
+}
+
+void start_app_messages(){
+    register_app_message_boxes();
+    app_message_open(inbox_size, outbox_size);
+}


### PR DESCRIPTION
Adds a return type for returning a text_struct when creating a new text element. This is so you can keep a reference to that element and access it without having to go through the array storing all of the text structs.